### PR TITLE
Use GitHub token instead of pat

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,3 +25,6 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew buildLanguages
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
         url "https://projects.itemis.de/nexus/content/repositories/mbeddr"
     }
 	maven {
-		url	"https://github.com/orgs/DSLFoundry/packages?repo_name=mps-testsupport"
+		url	"https://maven.pkg.github.com/DSLFoundry/mps-testsupport"
       credentials {
         username = System.getenv("MAVEN_USERNAME")
         password = System.getenv("MAVEN_PASSWORD")

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,11 @@ repositories {
         url "https://projects.itemis.de/nexus/content/repositories/mbeddr"
     }
 	maven {
-		url	"https://maven.pkg.github.com/DSLFoundry/mps-testsupport"
-		credentials {
-			username project.dslfoundryUsername
-			password project.dslfoundryPassword
-		}
+		url	"https://github.com/orgs/DSLFoundry/packages?repo_name=mps-testsupport"
+      credentials {
+        username = System.getenv("MAVEN_USERNAME")
+        password = System.getenv("MAVEN_PASSWORD")
+      }
 	}
 
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,3 @@
 testgeneratorVersion = 0.1.0
 systemProp.org.gradle.internal.http.connectionTimeout=180000
 systemProp.org.gradle.internal.http.socketTimeout=180000
-
-dslfoundryUsername=
-dslfoundryPassword=


### PR DESCRIPTION
enable installing mps-testsupport package from Github packages using GITHUB_TOKEN instead of PAT